### PR TITLE
Add missing files to Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,3 +13,13 @@ r3_include_HEADERS = \
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = r3.pc
+
+EXTRA_DIST = \
+	autogen.sh \
+	bench.html \
+	demo.c \
+	gen_routes.rb \
+	HACKING.md \
+	LICENSE \
+	README.md \
+	$(NULL)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,6 +6,14 @@
 # endif
 TESTS                       = check_tree
 
+noinst_HEADERS = \
+	bench.h \
+	$(NULL)
+
+dist_noinst_DATA = \
+	bench_str.csv \
+	$(NULL)
+
 if ENABLE_GRAPHVIZ
 TESTS += check_gvc
 check_gvc_SOURCES = check_gvc.c bench.c


### PR DESCRIPTION
Add missing files to `Makefile.am` so that `make dist` can create a complete release tarball.

I did not list all missing into `Makefile.am` because I am not sure if those files are needed or not. For example, `cmake_modules/*` and `php/*` will not be in release tarball when using `make dist`.
