### PR TITLE
Add coveralls.io support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,28 @@
 language: c
+
 compiler:
-  #  - clang
   - gcc
-# for debian
+
+matrix:
+  include:
+    - compiler: gcc
+      env: CONFIGURE_OPTION='--enable-debug' COVERALLS=yes
+
 install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq automake pkg-config build-essential libtool automake autoconf m4 gnulib
   - sudo apt-get install -qq check libpcre3 libpcre3-dev libjemalloc-dev libjemalloc1
   - sudo apt-get install -qq graphviz-dev graphviz 
-before_script:
-  #  - aclocal
-  #  - autoconf
-  #  - automake --add-missing --foreign
-  #  - autoreconf -i -I/usr/share/gnulib/m4 && ./configure && make
-  - ./autogen.sh
-  - ./configure && make
+  - if [ x$COVERALLS == xyes ]; then sudo pip install cpp-coveralls --use-mirror; fi
+
 script:
+  - ./autogen.sh
+  - ./configure $CONFIGURE_OPTION
+  - make
   - make check
+
+after_success:
+  - if [ x$COVERALLS == xyes ]; then coveralls ; fi
+
 cache:
   apt: true


### PR DESCRIPTION
Add coveralls.io support.

Just enable coveralls service in https://coveralls.io and it will generate coverage report for every pull.
