### PR TITLE
Fix pcre_exec's return type

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -327,7 +327,7 @@ node * r3_tree_matchl(const node * n, const char * path, int path_len, match_ent
         const char *substring_start = NULL;
         int   substring_length = 0;
         int   ov[ n->ov_cnt ];
-        char rc;
+        int   rc;
 
         info("pcre matching %s on %s\n", n->combined_pattern, path);
 


### PR DESCRIPTION
According to PCRE_EXEC(3) pcre_exec returns int.

The original code uses char but char could be either signed or
unsigned. On armel and sparc this caused segment fault because
the (rc < 0) error checking was optimized out.
