### PR TITLE
add r3_slug_find_name and rename slug_count to r3_slug_count

### DIFF
--- a/include/r3_str.h
+++ b/include/r3_str.h
@@ -14,7 +14,11 @@ char * r3_slug_compile(const char * str, int len);
 
 char * r3_slug_find_pattern(const char *s1, int *len);
 
+char * r3_slug_find_name(const char *s1, int *len);
+
 char * r3_slug_find_placeholder(const char *s1, int *len);
+
+int r3_slug_count(const char * needle, int len, char **errstr);
 
 char * r3_inside_slug(const char * needle, int needle_len, char *offset, char **errstr);
 

--- a/src/node.c
+++ b/src/node.c
@@ -615,7 +615,7 @@ node * r3_tree_insert_pathl_ex(node *tree, const char *path, int path_len, route
     // common prefix not found, insert a new edge for this pattern
     if ( prefix_len == 0 ) {
         // there are two more slugs, we should break them into several parts
-        int slug_cnt = slug_count(path, path_len, errstr);
+        int slug_cnt = r3_slug_count(path, path_len, errstr);
         if (slug_cnt == -1) {
             return NULL;
         }

--- a/src/slug.c
+++ b/src/slug.c
@@ -152,7 +152,7 @@ int r3_slug_parse(r3_slug_t *s, const char *needle, int needle_len, const char *
 /**
  * provide a quick way to count slugs, simply search for '{'
  */
-int slug_count(const char * needle, int len, char **errstr) {
+int r3_slug_count(const char * needle, int len, char **errstr) {
     int cnt = 0;
     int state = 0;
     char * p = (char*) needle;

--- a/src/slug.h
+++ b/src/slug.h
@@ -49,8 +49,6 @@ char * r3_slug_to_str(const r3_slug_t *s);
 
 void r3_slug_free(r3_slug_t * s);
 
-int slug_count(const char * needle, int len, char **errstr);
-
 static inline int r3_path_contains_slug_char(const char * str) {
     return strchr(str, '{') != NULL ? 1 : 0;
 }

--- a/src/str.c
+++ b/src/str.c
@@ -137,6 +137,37 @@ char * r3_slug_find_pattern(const char *s1, int *len) {
 
 
 /**
+ * given a slug string, duplicate the parameter name string of the slug
+ */
+char * r3_slug_find_name(const char *s1, int *len) {
+    char *c;
+    char *s2;
+    int cnt = 0;
+    c = s1;
+    
+    while(1) {
+        if(*c == '{') cnt++;
+        if(*c == '}') cnt--;
+        if(*c == ':') break;
+        if(*c == '\0') return NULL;
+        if(cnt == 0) break;
+        c++;        
+    }
+    
+    // find starting '{'
+    s2 = c;
+    while(1) {
+        if ( *s2 == '{' )
+            break;
+        s2--;
+    }
+    s2++;
+    *len = c - s2;
+    return s2;
+}
+
+
+/**
  * @param char * sep separator
  */
 char * r3_slug_compile(const char * str, int len)

--- a/tests/check_slug.c
+++ b/tests/check_slug.c
@@ -57,6 +57,29 @@ START_TEST (test_r3_slug_find_pattern)
 }
 END_TEST
 
+START_TEST (test_r3_slug_find_name)
+{
+    int len;
+    char * namerex = r3_slug_find_name("{name:\\s+}", &len);
+    ck_assert( strncmp(namerex, "name", len) == 0 );
+}
+END_TEST
+
+START_TEST (test_r3_slug_find_name_without_pattern)
+{
+    int len;
+    char * namerex = r3_slug_find_name("{name}", &len);
+    ck_assert( strncmp(namerex, "name", len) == 0 );
+}
+END_TEST
+
+START_TEST (test_r3_slug_find_name_with_multiple_slug)
+{
+    int len;
+    char * namerex = r3_slug_find_name("{name}/{name2}", &len);
+    ck_assert( strncmp(namerex, "name", len) == 0 );
+}
+END_TEST
 
 START_TEST (test_r3_slug_find_placeholder)
 {
@@ -87,7 +110,7 @@ START_TEST (test_incomplete_slug)
     int cnt = 0;
     char * errstr = NULL;
     char * pattern = "/user/{name:\\d{3}}/to/{id";
-    cnt = slug_count(pattern, strlen(pattern), &errstr);
+    cnt = r3_slug_count(pattern, strlen(pattern), &errstr);
     ck_assert_int_eq(cnt, -1);
     ck_assert(errstr);
     printf("%s\n",errstr);
@@ -138,22 +161,22 @@ END_TEST
 
 
 
-START_TEST (test_slug_count)
+START_TEST (test_r3_slug_count)
 {
     int cnt = 0;
     char * pattern = "/user/{name:\\s+}/to/{id}";
     char * errstr = NULL;
-    cnt = slug_count(pattern, strlen(pattern), &errstr);
+    cnt = r3_slug_count(pattern, strlen(pattern), &errstr);
     ck_assert_int_eq(cnt, 2);
     if(errstr) free(errstr);
 
     char * pattern2 = "/user/{name:\\d{3}}/to/{id}";
-    cnt = slug_count(pattern2, strlen(pattern2), &errstr);
+    cnt = r3_slug_count(pattern2, strlen(pattern2), &errstr);
     ck_assert_int_eq(cnt, 2);
     if(errstr) free(errstr);
 
     char * pattern3 = "/user/{name:\\d{3}}/to/{id}";
-    cnt = slug_count(pattern3, strlen(pattern3), &errstr);
+    cnt = r3_slug_count(pattern3, strlen(pattern3), &errstr);
     ck_assert_int_eq(cnt, 2);
     if(errstr) free(errstr);
 }
@@ -177,10 +200,14 @@ Suite* r3_suite (void) {
         tcase_add_test(tcase, test_r3_slug_find_pattern);
         tcase_add_test(tcase, test_r3_slug_find_placeholder);
         tcase_add_test(tcase, test_r3_slug_find_placeholder_with_broken_slug);
-        tcase_add_test(tcase, test_slug_count);
+        tcase_add_test(tcase, test_r3_slug_count);
         tcase_add_test(tcase, test_r3_slug_compile);
         tcase_add_test(tcase, test_pattern_to_opcode);
         tcase_add_test(tcase, test_incomplete_slug);
+        tcase_add_test(tcase, test_r3_slug_find_name);
+        tcase_add_test(tcase, test_r3_slug_find_name_without_pattern);
+        tcase_add_test(tcase, test_r3_slug_find_name_with_multiple_slug);
+        
         // tcase_add_test(tcase, test_slug_parse_with_pattern);
         // tcase_add_test(tcase, test_slug_parse_without_pattern);
 


### PR DESCRIPTION
add a new function to find slug parameter name.

name = r3_slug_find_name("{id:\\d+}", &len);

=====
name => "id"