### PR TITLE
Don't typedef bool if compiling with C++

### DIFF
--- a/include/r3_define.h
+++ b/include/r3_define.h
@@ -9,7 +9,7 @@
 #define DEFINE_H
 #include <stdbool.h>
 
-#ifndef bool
+#if !defined(bool) && !defined(__cplusplus)
 typedef unsigned char bool;
 #endif
 #ifndef FALSE


### PR DESCRIPTION
If using the C++ wrapper provided by r3.hpp, you get a compiler
error when r3_define.h tries to typedef bool as C++ already has
native bool type.  Modified the guard around this typedef
to include a check for C++ compilation (!defined(__cplusplus)).