### PR TITLE
add include config.h

### DIFF
--- a/src/match_entry.c
+++ b/src/match_entry.c
@@ -4,6 +4,7 @@
  *
  * Distributed under terms of the MIT license.
  */
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/token.c
+++ b/src/token.c
@@ -4,6 +4,7 @@
  *
  * Distributed under terms of the MIT license.
  */
+#include "config.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
add include config.h to prevent conflicting types for ‘strndup’
