### PR TITLE
Add include headers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ endif
 
 r3_includedir = $(includedir)/r3
 r3_include_HEADERS = \
+	include/memory.h \
 	include/r3.h \
 	include/r3_list.h \
 	include/r3_slug.h \

--- a/package.json
+++ b/package.json
@@ -5,5 +5,5 @@
   "description": "high-performance path dispatching library",
   "keywords": ["path", "dispatch", "performance", "r3", "c9s"],
   "license": "MIT",
-  "src": ["3rdparty/zmalloc.c", "3rdparty/zmalloc.h", "include/r3.h", "include/r3.hpp", "include/r3_gvc.h", "include/r3_json.h", "include/r3_list.h", "include/r3_slug.h", "include/str_array.h", "src/edge.c", "src/gvc.c", "src/json.c", "src/list.c", "src/match_entry.c", "src/node.c", "src/slug.c", "src/slug.h", "src/str.c", "src/token.c"]
+  "src": ["3rdparty/zmalloc.c", "3rdparty/zmalloc.h", "include/memory.h", "include/r3.h", "include/r3.hpp", "include/r3_gvc.h", "include/r3_json.h", "include/r3_list.h", "include/r3_slug.h", "include/str_array.h", "src/edge.c", "src/gvc.c", "src/json.c", "src/list.c", "src/match_entry.c", "src/node.c", "src/slug.c", "src/slug.h", "src/str.c", "src/token.c"]
 }


### PR DESCRIPTION
You get a compiler error after install because "memory.h" isn't copied to include directory.
I added "include/memory.h" to r3_include_headers in "Makefile.am" and "package.json" also to make install work well.
