### PR TITLE
Fix issues with check_tree test

### DIFF
--- a/.travis-ci/after_success.sh
+++ b/.travis-ci/after_success.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ x$COVERALLS == xyes ]; then
+    coveralls --exclude php --exclude 3rdparty
+fi

--- a/.travis-ci/install.sh
+++ b/.travis-ci/install.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+apt-get update -qq
+apt-get install -qq \
+    autoconf \
+    automake \
+    build-essential \
+    check \
+    clang \
+    graphviz-dev \
+    libjemalloc-dev \
+    libpcre3-dev \
+    libtool \
+    pkg-config
+
+if [ x$COVERALLS == xyes ]; then
+    pip install cpp-coveralls
+fi
+
+if [ x$VALGRIND == xyes ]; then
+    apt-get install valgrind
+fi

--- a/.travis-ci/script.sh
+++ b/.travis-ci/script.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -ev
+
+./autogen.sh
+./configure --enable-check $CONFIGURE_OPTION
+make V=1
+make install
+if [ x$VALGRIND == xyes ]; then
+    make check
+else
+    make check V=1
+fi
+
+# XXX: tracing memory leak, disabled for some mystery reason for automake...
+#if [ x$VALGRIND == xyes && x$DEBUG == xyes ]; then
+#    valgrind ./tests/check_* -v --trace-children=yes --show-leak-kinds=full --leak-check=full
+#fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: c
+sudo: required
+
+services:
+  - docker
 
 git:
   depth: 1
@@ -6,35 +10,49 @@ git:
 matrix:
   include:
   - compiler: gcc
-    env: CONFIGURE_OPTION='--enable-debug --enable-gcov --with-malloc=jemalloc' COVERALLS=yes VALGRIND=no DEBUG=yes
+    env:
+    - CONFIGURE_OPTION='--enable-debug --enable-gcov --with-malloc=jemalloc'
+    - COVERALLS=yes
+    - VALGRIND=no
+    - DEBUG=yes
+    - CC=gcc
+    - CXX=g++
   - compiler: gcc
-    env: CONFIGURE_OPTION='--enable-debug --enable-gcov' COVERALLS=yes VALGRIND=yes DEBUG=yes LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
+    env:
+    - CONFIGURE_OPTION='--enable-debug --enable-gcov'
+    - COVERALLS=yes
+    - VALGRIND=yes
+    - DEBUG=yes
+    - CC=gcc
+    - CXX=g++
   - compiler: clang
-    env: CONFIGURE_OPTION='--enable-debug --enable-gcov' COVERALLS=yes VALGRIND=yes DEBUG=yes LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
-  allow_failures:
-  - compiler: clang
-    env: ASAN_OPTIONS=symbolize=1 ASAN_SYMBOLIZER_PATH=/usr/local/clang-3.4/bin/llvm-symbolizer CFLAGS='-fsanitize=address -g -O1 -D_BSD_SOURCE=1' CXX=clang++ CXXFLAGS='-fsanitize=address -g -O1 -D_BSD_SOURCE=1'
-install:
-- sudo apt-get update -qq
-- sudo apt-get install -qq automake pkg-config build-essential libtool automake autoconf m4 gnulib
-- sudo apt-get install -qq check libpcre3 libpcre3-dev libjemalloc-dev libjemalloc1
-- sudo apt-get install -qq graphviz-dev graphviz
-- if [ "x$COVERALLS" == xyes ]; then sudo pip install cpp-coveralls; fi
-- if [ "x$VALGRIND" == xyes ]; then sudo apt-get install valgrind; fi
+    env:
+    - CONFIGURE_OPTION='--enable-debug --enable-gcov'
+    - COVERALLS=yes
+    - VALGRIND=yes
+    - DEBUG=yes
+    - CC=clang
+    - CXX=clang++
 
-before_script:
-  - sudo ldconfig
+before_install:
+  - docker run -d
+    --name build
+    -v $(pwd):/travis
+    -e "CONFIGURE_OPTION=$CONFIGURE_OPTION"
+    -e "COVERALLS=$COVERALLS"
+    -e "VALGRIND=$VALGRIND"
+    -e "DEBUG=$DEBUG"
+    -e "CC=$CC"
+    -e "CXX=$CXX"
+    ubuntu:16.04
+    tail -f /dev/null
+  - docker ps
+
+install:
+  - docker exec -t build bash -c "cd /travis && .travis-ci/install.sh"
+
 script:
-  - ./autogen.sh
-  - ./configure --enable-check $CONFIGURE_OPTION
-  - make V=1
-  - sudo make install
-  - if [ "x$VALGRIND" == xyes ]; then make check ; else make check V=1; fi
-  # XXX: tracing memory leak, disabled for some mystery reason for automake...
-  # - if [ "x$VALGRIND" == xyes && "x$DEBUG" == xyes ]; then valgrind ./tests/check_* -v --trace-children=yes --show-leak-kinds=full --leak-check=full; fi
+  - docker exec -t build bash -c "cd /travis && .travis-ci/script.sh"
 
 after_success:
-  - if [ x$COVERALLS == xyes ]; then coveralls --exclude php --exclude 3rdparty; fi
-
-cache:
-  apt: true
+  - docker exec -t build bash -c "cd /travis && .travis-ci/after_success.sh"

--- a/src/node.c
+++ b/src/node.c
@@ -218,6 +218,7 @@ int r3_tree_compile_patterns(R3Node * n, char **errstr) {
     }
     info("COMPARE_TYPE: %d\n",n->compare_type);
 
+    zfree(n->combined_pattern);
     n->combined_pattern = cpat;
 
     const char *pcre_error;

--- a/tests/check_tree.c
+++ b/tests/check_tree.c
@@ -286,26 +286,34 @@ START_TEST (test_compile)
     entry = match_entry_createl( "foo" , strlen("/foo") );
     m = r3_tree_matchl( n , "/foo", strlen("/foo"), entry);
     ck_assert( m );
+    match_entry_free(entry);
 
     entry = match_entry_createl( "/zoo" , strlen("/zoo") );
     m = r3_tree_matchl( n , "/zoo", strlen("/zoo"), entry);
     ck_assert( m );
+    match_entry_free(entry);
 
     entry = match_entry_createl( "/bar" , strlen("/bar") );
     m = r3_tree_matchl( n , "/bar", strlen("/bar"), entry);
     ck_assert( m );
+    match_entry_free(entry);
 
     entry = match_entry_createl( "/xxx" , strlen("/xxx") );
     m = r3_tree_matchl( n , "/xxx", strlen("/xxx"), entry);
     ck_assert( m );
+    match_entry_free(entry);
 
     entry = match_entry_createl( "/foo/xxx" , strlen("/foo/xxx") );
     m = r3_tree_matchl( n , "/foo/xxx", strlen("/foo/xxx"), entry);
     ck_assert( m );
+    match_entry_free(entry);
 
     entry = match_entry_createl( "/some_id" , strlen("/some_id") );
     m = r3_tree_matchl( n , "/some_id", strlen("/some_id"), entry);
     ck_assert( m );
+    match_entry_free(entry);
+
+    r3_tree_free(n);
 }
 END_TEST
 
@@ -439,6 +447,8 @@ START_TEST (test_root_match)
     ck_assert(matched);
     ck_assert(matched->data == &c);
     ck_assert(matched->endpoint > 0);
+
+    r3_tree_free(n);
 }
 END_TEST
 
@@ -464,6 +474,8 @@ START_TEST (test_pcre_patterns_insert_2)
     matched = r3_tree_match(n, "/post/11/22", NULL);
     ck_assert(matched);
     ck_assert(matched->endpoint > 0);
+
+    r3_tree_free(n);
 }
 END_TEST
 
@@ -504,6 +516,8 @@ START_TEST (test_pcre_patterns_insert_3)
     matched = r3_tree_match(n, "/post/113", NULL);
     ck_assert(!matched);
     */
+
+    r3_tree_free(n);
 }
 END_TEST
 
@@ -646,7 +660,6 @@ START_TEST(test_route_cmp)
     m->request_method = METHOD_POST | METHOD_GET;
     fail_if( r3_route_cmp(r1, m) == -1, "should match");
 
-    r3_route_free(r1);
     match_entry_free(m);
     r3_tree_free(n);
 }
@@ -667,6 +680,7 @@ START_TEST(test_pcre_pattern_simple)
     ck_assert(matched);
     ck_assert(entry->vars.tokens.size > 0);
     ck_assert_str_eq(entry->vars.tokens.entries[0].base,"123");
+    match_entry_free(entry);
     r3_tree_free(n);
 }
 END_TEST
@@ -719,6 +733,7 @@ START_TEST(test_pcre_pattern_more)
     info("matched %p\n", matched->data);
     ck_assert_int_eq( *((int*)matched->data), var3);
 
+    match_entry_free(entry);
     r3_tree_free(n);
 }
 END_TEST


### PR DESCRIPTION
This patch fixes a few issues in the check_tree test:

* Fix various memory leaks in test code
* Fix a double-free in test code
* Fix a memory leak in r3_tree_compile_patterns

One memory leak remains in the library code but it isn't obvious to me
how to fix it at the moment.