### PR TITLE
feature: returned the matching node directly if enabled `match_early` argument.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,9 @@ tests/bench_str.csv
 config.h.in
 examples/simple
 examples/simple_cpp
+
+tests/bench
+tests/check_routes
+tests/check_slug
+tests/check_str_array
+tests/check_tree

--- a/include/r3.h
+++ b/include/r3.h
@@ -149,6 +149,10 @@ int r3_tree_compile_patterns(R3Node * n, char** errstr);
 
 R3Node * r3_tree_matchl(const R3Node * n, const char * path, unsigned int path_len, match_entry * entry);
 
+R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int path_len, match_entry * entry, int match_mode);
+
+#define r3_tree_matchl(n,p,l,e) r3_tree_matchl_ex(n, p, l, e, 0)
+
 #define r3_tree_match(n,p,e)  r3_tree_matchl(n,p, strlen(p), e)
 
 // R3Node * r3_tree_match_entry(R3Node * n, match_entry * entry);

--- a/include/r3.h
+++ b/include/r3.h
@@ -97,7 +97,7 @@ struct _R3Entry {
     r3_iovec_t host; // the request host
     r3_iovec_t remote_addr;
 
-    const char *unmatched_path;
+    const char * unmatched_path;
 } __attribute__((aligned(64)));
 
 
@@ -151,7 +151,8 @@ int r3_tree_compile_patterns(R3Node * n, char** errstr);
 
 R3Node * r3_tree_matchl(const R3Node * n, const char * path, unsigned int path_len, match_entry * entry);
 
-R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int path_len, match_entry * entry, int match_early, const char **unmatched_path);
+R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int path_len, 
+    match_entry * entry, int match_early, const char **unmatched_path);
 
 #define r3_tree_matchl(n,p,l,e) r3_tree_matchl_ex(n, p, l, e, 0, NULL)
 

--- a/include/r3.h
+++ b/include/r3.h
@@ -96,6 +96,8 @@ struct _R3Entry {
 
     r3_iovec_t host; // the request host
     r3_iovec_t remote_addr;
+
+    const char *unmatched_path;
 } __attribute__((aligned(64)));
 
 
@@ -149,14 +151,18 @@ int r3_tree_compile_patterns(R3Node * n, char** errstr);
 
 R3Node * r3_tree_matchl(const R3Node * n, const char * path, unsigned int path_len, match_entry * entry);
 
-R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int path_len, match_entry * entry, int match_mode);
+R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int path_len, match_entry * entry, int match_early, const char **unmatched_path);
 
-#define r3_tree_matchl(n,p,l,e) r3_tree_matchl_ex(n, p, l, e, 0)
+#define r3_tree_matchl(n,p,l,e) r3_tree_matchl_ex(n, p, l, e, 0, NULL)
 
 #define r3_tree_match(n,p,e)  r3_tree_matchl(n,p, strlen(p), e)
 
 // R3Node * r3_tree_match_entry(R3Node * n, match_entry * entry);
 #define r3_tree_match_entry(n, entry) r3_tree_matchl(n, entry->path.base, entry->path.len, entry)
+#define r3_tree_match_entry_early(n, entry) \
+            r3_tree_matchl_ex(n, entry->unmatched_path, \
+                entry->path.base + entry->path.len - entry->unmatched_path, \
+                entry, 1, &(entry->unmatched_path))
 
 bool r3_node_has_slug_edges(const R3Node *n);
 
@@ -182,6 +188,8 @@ R3Route * r3_node_append_route(R3Node *tree, const char * path, int path_len, in
 void r3_route_free(R3Route * route);
 
 int r3_route_cmp(const R3Route *r1, const match_entry *r2);
+
+R3Route * r3_node_match_route(const R3Node *n, match_entry * entry);
 
 R3Route * r3_tree_match_route(const R3Node *n, match_entry * entry);
 

--- a/src/match_entry.c
+++ b/src/match_entry.c
@@ -20,6 +20,7 @@ match_entry * match_entry_createl(const char * path, int path_len) {
     r3_vector_reserve(NULL, &entry->vars.tokens, 3);
     entry->path.base = path;
     entry->path.len = path_len;
+    entry->unmatched_path = path;
     return entry;
 }
 

--- a/src/node.c
+++ b/src/node.c
@@ -270,7 +270,7 @@ int r3_tree_compile_patterns(R3Node * n, char **errstr) {
  * @param int          path_len the length of the URL path.
  * @param match_entry* entry match_entry is used for saving the captured dynamic strings from pcre result.
  */
-R3Node * r3_tree_matchl(const R3Node * n, const char * path, unsigned int path_len, match_entry * entry) {
+R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int path_len, match_entry * entry, int match_early) {
     info("try matching: %s\n", path);
 
     R3Edge *e;
@@ -314,6 +314,13 @@ R3Node * r3_tree_matchl(const R3Node * n, const char * path, unsigned int path_l
                     str_array_append(&entry->vars , path, pp - path);
                 }
                 restlen = pp_end - pp;
+                
+                if (match_early) {
+                    if (e->child && e->child->endpoint) {
+                        return e->child;
+                    }
+                }
+                
                 if (!restlen) {
                     return e->child && e->child->endpoint ? e->child : NULL;
                 }
@@ -424,6 +431,12 @@ R3Node * r3_tree_matchl(const R3Node * n, const char * path, unsigned int path_l
 
     if ((e = r3_node_find_edge_str(n, path, path_len))) {
         restlen = path_len - e->pattern.len;
+        if (match_early) {
+            if (e->child && e->child->endpoint) {
+                return e->child;
+            }
+        }
+
         if (!restlen) {
             return e->child && e->child->endpoint ? e->child : NULL;
         }

--- a/src/node.c
+++ b/src/node.c
@@ -128,8 +128,8 @@ R3Edge * r3_node_find_edge(const R3Node * n, const char * pat, unsigned int pat_
     for (i = 0 ; i < n->edges.size ; i++ ) {
         e = edge_entries + i;
         // there is a case: "{foo}" vs "{foo:xxx}",
-        // we should return the match result: full-match or partial-match 
-        if (e->pattern.len == pat_len && 
+        // we should return the match result: full-match or partial-match
+        if (e->pattern.len == pat_len &&
             !strncmp(e->pattern.base, pat, e->pattern.len)) {
             return e;
         }
@@ -314,15 +314,15 @@ R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int pat
                     str_array_append(&entry->vars , path, pp - path);
                 }
                 restlen = pp_end - pp;
-                
+
                 if (match_early && e->child && e->child->endpoint) {
                     return e->child;
                 }
-                
+
                 if (!restlen) {
                     return e->child && e->child->endpoint ? e->child : NULL;
                 }
-                return r3_tree_matchl(e->child, pp, restlen, entry);
+                return r3_tree_matchl_ex(e->child, pp, restlen, entry, match_early);
             }
             e++;
         }
@@ -374,7 +374,7 @@ R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int pat
         int *inv = ov + 2;
 
         if (match_early || !restlen) {
-            // Check the substring to decide we should go deeper on which edge 
+            // Check the substring to decide we should go deeper on which edge
             for (i = 1; i < rc; i++)
             {
                 substring_length = *(inv+1) - *inv;
@@ -395,7 +395,7 @@ R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int pat
                     }
 
                     return e->child;
-                }   
+                }
 
                 if (!restlen) {
                     if (entry && e->has_slug) {
@@ -410,7 +410,7 @@ R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int pat
         }
 
 
-        // Check the substring to decide we should go deeper on which edge 
+        // Check the substring to decide we should go deeper on which edge
         inv = ov + 2;
         for (i = 1; i < rc; i++)
         {
@@ -431,7 +431,7 @@ R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int pat
             }
 
             // get the length of orginal string: $0
-            return r3_tree_matchl( e->child, path + (ov[1] - ov[0]), restlen, entry);
+            return r3_tree_matchl_ex( e->child, path + (ov[1] - ov[0]), restlen, entry, match_early);
         }
         // does not match
         return NULL;
@@ -442,13 +442,13 @@ R3Node * r3_tree_matchl_ex(const R3Node * n, const char * path, unsigned int pat
     if ((e = r3_node_find_edge_str(n, path, path_len))) {
         restlen = path_len - e->pattern.len;
         if (match_early && e->child && e->child->endpoint) {
-                return e->child;
-            }
+            return e->child;
+        }
 
         if (!restlen) {
             return e->child && e->child->endpoint ? e->child : NULL;
         }
-        return r3_tree_matchl(e->child, path + e->pattern.len, restlen, entry);
+        return r3_tree_matchl_ex(e->child, path + e->pattern.len, restlen, entry, match_early);
     }
     return NULL;
 }
@@ -579,7 +579,7 @@ R3Route * r3_tree_insert_routel_ex(R3Node *tree, int method, const char *path, i
     R3Node * ret = r3_tree_insert_pathl_ex(tree, path, path_len, method, 1, data, errstr);
     R3Route *router = ret->routes.entries + (ret->routes.size - 1);
     get_slugs(router, path, path_len);
-    
+
     return router;
 }
 
@@ -754,7 +754,7 @@ R3Node * r3_tree_insert_pathl_ex(R3Node *tree, const char *path, unsigned int pa
                 }
 
                 R3Node * c2 = r3_tree_create(3);
-                
+
                 R3Edge * op_edge = r3_node_connectl(c1, slug_p, slug_len , 0, c2);
                 if(opcode) {
                     op_edge->opcode = opcode;
@@ -876,7 +876,7 @@ void r3_tree_dump(const R3Node * n, int level) {
 
         print_indent(level + 1);
         printf("||-routes num: |%d|", n->routes.size);
-            
+
         for ( int j = 0 ; j < n->routes.size ; j++ ) {
             R3Route * rr = n->routes.entries + j;
             printf(" route path: |%*.*s|", rr->path.len,rr->path.len,rr->path.base);
@@ -928,7 +928,7 @@ inline int r3_route_cmp(const R3Route *r1, const match_entry *r2) {
 /**
  *
  */
-// void r3_node_append_route(R3Node * n, R3Route * r) 
+// void r3_node_append_route(R3Node * n, R3Route * r)
 // {
 //     r3_vector_reserve(NULL, &n->routes, n->routes.size + 1);
 //     memset(n->routes.entries + 1, 0, sizeof(*n->routes.entries));


### PR DESCRIPTION
todo items:

- [ ] doc
- [x] test case