### PR TITLE
make: avoided the warning message when do make at Ubuntu OS.

### DIFF
--- a/src/gvc.c
+++ b/src/gvc.c
@@ -24,9 +24,11 @@ void r3_tree_build_ag_nodes(Agraph_t * g, Agnode_t * ag_parent_node, const node 
 
         char *nodename = NULL;
         if ( e && e->child && e->child->combined_pattern ) {
-            asprintf(&nodename,"%s", e->child->combined_pattern);
+            int r = asprintf(&nodename,"%s", e->child->combined_pattern);
+            if (r) {};
         } else {
-            asprintf(&nodename,"#%d", *node_cnt);
+            int r = asprintf(&nodename,"#%d", *node_cnt);
+            if (r) {};
         }
 
         agn_child = agnode(g, nodename, 1);

--- a/src/node.c
+++ b/src/node.c
@@ -56,9 +56,9 @@ static int strdiff(char * d1, char * d2) {
 R3Node * r3_tree_create(int cap) {
     R3Node * n = r3_mem_alloc( sizeof(R3Node) );
     memset(n, 0, sizeof(*n));
-    
+
     r3_vector_reserve(NULL, &n->edges, n->edges.size + cap);
-    
+
     r3_vector_reserve(NULL, &n->routes, n->routes.size + 1);
 
     n->compare_type = NODE_COMPARE_PCRE;
@@ -130,8 +130,8 @@ R3Edge * r3_node_find_edge(const R3Node * n, const char * pat, unsigned int pat_
     for (i = 0 ; i < n->edges.size ; i++ ) {
         e = edge_entries + i;
         // there is a case: "{foo}" vs "{foo:xxx}",
-        // we should return the match result: full-match or partial-match 
-        if (e->pattern.len == pat_len && 
+        // we should return the match result: full-match or partial-match
+        if (e->pattern.len == pat_len &&
             !strncmp(e->pattern.base, pat, e->pattern.len)) {
             return e;
         }
@@ -173,7 +173,8 @@ int r3_tree_compile_patterns(R3Node * n, char **errstr) {
     char * p;
     char * cpat = calloc(1, sizeof(char) * 64 * 3); // XXX
     if (!cpat) {
-        asprintf(errstr, "Can not allocate memory");
+        int r = asprintf(errstr, "Can not allocate memory");
+        if (r) {};
         return -1;
     }
 
@@ -239,7 +240,8 @@ int r3_tree_compile_patterns(R3Node * n, char **errstr) {
             NULL);                /* use default character tables */
     if (n->pcre_pattern == NULL) {
         if (errstr) {
-            asprintf(errstr, "PCRE compilation failed at offset %d: %s, pattern: %s", pcre_erroffset, pcre_error, n->combined_pattern);
+            int r = asprintf(errstr, "PCRE compilation failed at offset %d: %s, pattern: %s", pcre_erroffset, pcre_error, n->combined_pattern);
+            if (r) {};
         }
         return -1;
     }
@@ -250,7 +252,8 @@ int r3_tree_compile_patterns(R3Node * n, char **errstr) {
     n->pcre_extra = pcre_study(n->pcre_pattern, 0, &pcre_error);
     if (!n->pcre_extra) {
         if (errstr) {
-            asprintf(errstr, "PCRE study failed at offset %s, pattern: %s", pcre_error, n->combined_pattern);
+            int r = asprintf(errstr, "PCRE study failed at offset %s, pattern: %s", pcre_error, n->combined_pattern);
+            if (r) {};
         }
         return -1;
     }
@@ -370,7 +373,7 @@ R3Node * r3_tree_matchl(const R3Node * n, const char * path, unsigned int path_l
         restlen = path_len - ov[1]; // if it's fully matched to the end (rest string length)
         int *inv = ov + 2;
         if (!restlen) {
-            // Check the substring to decide we should go deeper on which edge 
+            // Check the substring to decide we should go deeper on which edge
             for (i = 1; i < rc; i++)
             {
                 substring_length = *(inv+1) - *inv;
@@ -395,7 +398,7 @@ R3Node * r3_tree_matchl(const R3Node * n, const char * path, unsigned int path_l
         }
 
 
-        // Check the substring to decide we should go deeper on which edge 
+        // Check the substring to decide we should go deeper on which edge
         inv = ov + 2;
         for (i = 1; i < rc; i++)
         {
@@ -560,7 +563,7 @@ R3Route * r3_tree_insert_routel_ex(R3Node *tree, int method, const char *path, i
     R3Node * ret = r3_tree_insert_pathl_ex(tree, path, path_len, method, 1, data, errstr);
     R3Route *router = ret->routes.entries + (ret->routes.size - 1);
     get_slugs(router, path, path_len);
-    
+
     return router;
 }
 
@@ -735,7 +738,7 @@ R3Node * r3_tree_insert_pathl_ex(R3Node *tree, const char *path, unsigned int pa
                 }
 
                 R3Node * c2 = r3_tree_create(3);
-                
+
                 R3Edge * op_edge = r3_node_connectl(c1, slug_p, slug_len , 0, c2);
                 if(opcode) {
                     op_edge->opcode = opcode;
@@ -857,7 +860,7 @@ void r3_tree_dump(const R3Node * n, int level) {
 
         print_indent(level + 1);
         printf("||-routes num: |%d|", n->routes.size);
-            
+
         for ( int j = 0 ; j < n->routes.size ; j++ ) {
             R3Route * rr = n->routes.entries + j;
             printf(" route path: |%*.*s|", rr->path.len,rr->path.len,rr->path.base);
@@ -928,7 +931,7 @@ inline int r3_route_cmp(const R3Route *r1, const match_entry *r2) {
 /**
  *
  */
-// void r3_node_append_route(R3Node * n, R3Route * r) 
+// void r3_node_append_route(R3Node * n, R3Route * r)
 // {
 //     r3_vector_reserve(NULL, &n->routes, n->routes.size + 1);
 //     memset(n->routes.entries + 1, 0, sizeof(*n->routes.entries));

--- a/src/slug.c
+++ b/src/slug.c
@@ -60,7 +60,8 @@ int r3_slug_check(r3_slug_t *s) {
 
 char * r3_slug_to_str(const r3_slug_t *s) {
     char *str = NULL;
-    asprintf(&str, "slug: '%.*s', pattern: '%.*s', path: '%.*s'", s->len, s->begin, s->pattern_len, s->pattern, s->path_len, s->path);
+    int r = asprintf(&str, "slug: '%.*s', pattern: '%.*s', path: '%.*s'", s->len, s->begin, s->pattern_len, s->pattern, s->path_len, s->path);
+    if (r) {};
     return str;
 }
 
@@ -139,7 +140,8 @@ int r3_slug_parse(r3_slug_t *s, const char *needle, int needle_len, const char *
     if (state != 0) {
         if (errstr) {
             char *err = NULL;
-            asprintf(&err, "Incomplete slug pattern. PATH (%d): '%s', OFFSET: %ld, STATE: %d", needle_len, needle, p - needle, state);
+            int r = asprintf(&err, "Incomplete slug pattern. PATH (%d): '%s', OFFSET: %ld, STATE: %d", needle_len, needle, p - needle, state);
+            if (r) {};
             *errstr = err;
         }
         return -1;
@@ -177,7 +179,8 @@ int r3_slug_count(const char * needle, int len, char **errstr) {
     if (state != 0) {
         if (errstr) {
             char *err = NULL;
-            asprintf(&err, "Incomplete slug pattern. PATTERN (%d): '%s', OFFSET: %ld, STATE: %d", len, needle, p - needle, state);
+            int r = asprintf(&err, "Incomplete slug pattern. PATTERN (%d): '%s', OFFSET: %ld, STATE: %d", len, needle, p - needle, state);
+            if (r) {};
             *errstr = err;
         }
         return -1;

--- a/src/str.c
+++ b/src/str.c
@@ -78,7 +78,8 @@ char * r3_inside_slug(const char * needle, int needle_len, char *offset, char **
     if (found_s1 || found_s2) {
         // wrong slug pattern
         if(errstr) {
-            asprintf(errstr, "Incomplete slug pattern");
+            int r = asprintf(errstr, "Incomplete slug pattern");
+            if (r) {};
         }
         return NULL;
     }


### PR DESCRIPTION
change: code style, delete some useless spaces(visual code).

eg:

warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result

![image](https://user-images.githubusercontent.com/6814606/59894132-f6f33680-9411-11e9-9462-92ffa15cd640.png)
