### PR TITLE
fix : build failed since cannot find pcre lib on centos #132

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,9 +9,8 @@ libr3_la_SOURCES =
 libr3_la_LIBADD = src/libr3core.la
 libr3_la_LDFLAGS =
 
-AM_CFLAGS=$(DEPS_CFLAGS) $(GVC_DEPS_CFLAGS) -I$(top_builddir) -I$(top_builddir)/include -Wall -std=c99
-AM_LDFLAGS=$(DEPS_LIBS) $(GVC_DEPS_LIBS)
-
+AM_CFLAGS= $(DEPS_CFLAGS) $(R3_CC_OPT) $(GVC_DEPS_CFLAGS) -I$(top_builddir) -I$(top_builddir)/include -Wall -std=c99
+AM_LDFLAGS=$(DEPS_LIBS) $(R3_LD_OPT) $(GVC_DEPS_LIBS)
 
 ACLOCAL_AMFLAGS=-I m4
 

--- a/README.md
+++ b/README.md
@@ -383,6 +383,9 @@ And we support debian-based distro now!
 
     ./configure --with-malloc=jemalloc
 
+#### With pcre
+    ./configure --with-pcre=pcre-config path  # such as /usr/local/bin/pcre-config 
+
 ubuntu PPA
 ----------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -95,23 +95,30 @@ AC_ARG_WITH(pcre, [
   --with-pcre=PATH     Enable pcre support.  PATH is location of pcre-config.
                        Default is to enable and look for pcre-config in your
                        $PATH
+  --without-pcre       Don't enable pcre support
 ],[
-  pcre_config="$withval"
+  
 ],[
   pcre_config="check"
 ])
 
-AC_ARG_WITH(pcre, [
-  --without-pcre       Don't enable pcre support.
-],[
-  pcre_config="no"
-])
+AS_ECHO(["with_pcre=$with_pcre, withval=$withval"])
+
+# --with-pcre
+if test "x$with_pcre" != "xno" -a "x$withval" != "xyes" ; then
+    pcre_config=$withval
+fi
+
+# --without-pcre
+if test "x$with_pcre" == "xno" ; then
+   pcre_config="no"
+fi
 
 AS_ECHO(["pcre_config=$pcre_config"])
 
 if test "x$pcre_config" != "xno" ; then
   AS_ECHO(["pcre_config=$pcre_config"])
-  if test "$pcre_config" = "yes" -o "$pcre_config" = "check"; then
+  if test "$pcre_config" = "check"; then
     AC_PATH_PROG(PCRE_CONFIG_PATH, pcre-config, false)
     dnl If --with-pcre was specified but pcre-config not found, fail hard now.
     if test "$pcre_config" = "yes" -a "$PCRE_CONFIG_PATH" = "false"; then

--- a/configure.ac
+++ b/configure.ac
@@ -72,10 +72,60 @@ AM_CONDITIONAL(USE_JEMALLOC, test "x$have_jemalloc" = "xyes")
 # AM_CONDITIONAL(USE_JEMALLOC, test "x$found_jemalloc" = "xyes")
 # AC_DEFINE(USE_JEMALLOC, test "x$found_jemalloc" = "xyes" , "use jemalloc")
 
+AC_ARG_WITH(pcre, [
+  --without-pcre       Don't enable pcre support.
+  --with-pcre=PATH     Enable pcre support.  PATH is location of pcre-config.
+                       Default is to enable and look for pcre-config in your
+                       $PATH
+],[
+  pcre_config="$withval"
+],[
+  pcre_config="check"
+])
 
-PKG_CHECK_MODULES(DEPS, [libpcre])
-AC_SUBST(DEPS_CFLAGS)
-AC_SUBST(DEPS_LIBS)
+if test "x$pcre_config" != "xno" ; then
+  AS_ECHO(["pcre_config=$pcre_config"])
+  if test "$pcre_config" = "yes" -o "$pcre_config" = "check"; then
+    AC_PATH_PROG(PCRE_CONFIG_PATH, pcre-config, false)
+    dnl If --with-pcre was specified but pcre-config not found, fail hard now.
+    if test "$pcre_config" = "yes" -a "$PCRE_CONFIG_PATH" = "false"; then
+      AC_MSG_FAILURE([--with-pcre was given, but pcre-config not found in PATH])
+    fi
+  else
+    PCRE_CONFIG_PATH="$pcre_config"
+  fi
+
+  AC_MSG_CHECKING(for PCRE using $PCRE_CONFIG_PATH)
+  pcre_version=`"$PCRE_CONFIG_PATH" --version 2>/dev/null`
+  if test $? -ne 0; then
+    AC_MSG_RESULT(failed)
+  else
+    AC_MSG_RESULT($pcre_version)
+  fi
+
+  if test -n "$pcre_version"; then
+    DEPS_LIBS=`$PCRE_CONFIG_PATH --libs`
+    DEPS_CFLAGS=`$PCRE_CONFIG_PATH --cflags`
+    AC_SUBST(DEPS_LIBS)
+    AC_SUBST(DEPS_CFLAGS)
+    AC_CHECK_HEADERS(pcre.h, [], [
+      if test "$pcre_config" != "check"; then
+         AC_MSG_FAILURE([--with-pcre was given, but pcre not found:
+             pcre-config --libs=$PCRE_LIBS
+             pcre-config --cflags=$PCRE_CFLAGS])
+      fi
+    ])
+  elif test "$pcre_config" != "check"; then
+    AC_MSG_FAILURE([$PCRE_CONFIG_PATH failed to run, could not check for PCRE])
+  fi
+fi
+
+
+AS_ECHO(["DEPS_LIBS = $DEPS_LIBS"])
+
+#PKG_CHECK_MODULES(DEPS, [libpcre])
+#AC_SUBST(DEPS_CFLAGS)
+#AC_SUBST(DEPS_LIBS)
 
 
 AC_ARG_ENABLE(debug,AS_HELP_STRING([--enable-debug],[enable debug]))

--- a/configure.ac
+++ b/configure.ac
@@ -72,8 +72,26 @@ AM_CONDITIONAL(USE_JEMALLOC, test "x$have_jemalloc" = "xyes")
 # AM_CONDITIONAL(USE_JEMALLOC, test "x$found_jemalloc" = "xyes")
 # AC_DEFINE(USE_JEMALLOC, test "x$found_jemalloc" = "xyes" , "use jemalloc")
 
+AC_ARG_WITH(cc-opt, [
+  --with-cc-opt= cc    set additional C compiler options    
+],[
+  R3_CC_OPT="$withval"
+],[
+  R3_CC_OPT=""
+])
+
+AC_ARG_WITH(ld-opt, [
+  --with-ld-opt= cc    set additional C link options
+],[
+  R3_LD_OPT="$withval"
+],[
+  R3_LD_OPT=""
+])
+
+AC_SUBST(R3_CC_OPT)
+AC_SUBST(R3_LD_OPT)
+
 AC_ARG_WITH(pcre, [
-  --without-pcre       Don't enable pcre support.
   --with-pcre=PATH     Enable pcre support.  PATH is location of pcre-config.
                        Default is to enable and look for pcre-config in your
                        $PATH
@@ -82,6 +100,14 @@ AC_ARG_WITH(pcre, [
 ],[
   pcre_config="check"
 ])
+
+AC_ARG_WITH(pcre, [
+  --without-pcre       Don't enable pcre support.
+],[
+  pcre_config="no"
+])
+
+AS_ECHO(["pcre_config=$pcre_config"])
 
 if test "x$pcre_config" != "xno" ; then
   AS_ECHO(["pcre_config=$pcre_config"])

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,6 +1,6 @@
-AM_CFLAGS=$(DEPS_CFLAGS) $(GVC_DEPS_CFLAGS) -I$(top_builddir)/include -Wall -std=c99
+AM_CFLAGS=$(DEPS_CFLAGS) $(R3_CC_OPT) $(GVC_DEPS_CFLAGS) -I$(top_builddir)/include -Wall -std=c99
 AM_CXXFLAGS=$(DEPS_CFLAGS) $(GVC_DEPS_CFLAGS) -I$(top_builddir)/include -Wall
-AM_LDFLAGS=$(DEPS_LIBS) $(GVC_DEPS_LIBS) $(top_builddir)/libr3.la
+AM_LDFLAGS=$(DEPS_LIBS) $(R3_LD_OPT) $(GVC_DEPS_LIBS) $(top_builddir)/libr3.la
 
 noinst_PROGRAMS = simple simple_cpp
 simple_SOURCES = simple.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
-AM_CFLAGS=$(DEPS_CFLAGS) $(GVC_DEPS_CFLAGS) $(JSONC_CFLAGS) -I$(top_builddir) -I$(top_builddir)/include -Wall -std=c99
-AM_LDFLAGS=$(DEPS_LIBS) $(GVC_DEPS_LIBS) $(JSONC_LIBS)
+AM_CFLAGS=$(DEPS_CFLAGS) $(R3_CC_OPT) $(GVC_DEPS_CFLAGS) $(JSONC_CFLAGS) -I$(top_builddir) -I$(top_builddir)/include -Wall -std=c99
+AM_LDFLAGS=$(DEPS_LIBS) $(R3_LD_OPT) $(GVC_DEPS_LIBS) $(JSONC_LIBS)
 MAYBE_COVERAGE=--coverage
 
 noinst_LTLIBRARIES = libr3core.la

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,7 @@
 TESTS =
 
-AM_CFLAGS=$(DEPS_CFLAGS) $(GVC_DEPS_CFLAGS) $(JSONC_CFLAGS) @CHECK_CFLAGS@ -I$(top_builddir) -I$(top_builddir)/include -I$(top_builddir)/src -Wall -std=c99 -ggdb `pkg-config --cflags --libs check`
-AM_LDFLAGS=$(DEPS_LIBS) $(GVC_DEPS_LIBS) $(JSONC_LIBS) @CHECK_LIBS@ $(top_builddir)/libr3.la
+AM_CFLAGS=$(DEPS_CFLAGS) $(R3_CC_OPT) $(GVC_DEPS_CFLAGS) $(JSONC_CFLAGS) @CHECK_CFLAGS@ -I$(top_builddir) -I$(top_builddir)/include -I$(top_builddir)/src -Wall -std=c99 -ggdb `pkg-config --cflags --libs check`
+AM_LDFLAGS=$(DEPS_LIBS) $(R3_LD_OPT) $(GVC_DEPS_LIBS) $(JSONC_LIBS) @CHECK_LIBS@ $(top_builddir)/libr3.la
 
 if USE_JEMALLOC
 AM_CFLAGS += -ljemalloc


### PR DESCRIPTION
add with-pcre option to fix this issue, if no pcre option will link default pcre-config file, otherwise link target pcre-config file, such as /usr/local/bin/pcre-config.

add with-cc-opt and with-ld-opt to add C compiler and link option.