### PR TITLE
bugfix: insert path success, but get data failed

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -690,6 +690,7 @@ R3Node * r3_tree_insert_pathl_ex(R3Node *tree, const char *path, unsigned int pa
             r3_node_append_route(tree, path, path_len, method, data);
             info("tree router path is: %s, with len: %d\n", path, path_len);
         }
+        tree->data = data;
         return tree;
     }
 


### PR DESCRIPTION
background : use  r3_tree_insert_pathl_ex to add path，A ： abcdefg   B：abc
When the node A already exists， we set B, then  will split the node and make a branch, suboath_len  is 0 
In this case,  branch a  zero len subpath, which tree's data not set