### PR TITLE
Correcting leaks in tests

### DIFF
--- a/tests/check_host.c
+++ b/tests/check_host.c
@@ -29,14 +29,13 @@ START_TEST (test_hosts)
     r3_tree_compile(n, &err);
     ck_assert(err == NULL);
 
-
     entry = match_entry_create("/foo");
     entry->host.base = host0;
     entry->host.len = strlen(host0);
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri0);
-
+    match_entry_free(entry);
 
     entry = match_entry_create("/bar");
     entry->host.base = "www.bar.com";
@@ -44,19 +43,21 @@ START_TEST (test_hosts)
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri1);
-
+    match_entry_free(entry);
 
     entry = match_entry_create("/bar");
     entry->host.base = "bar.com";
     entry->host.len = strlen("bar.com");
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
+    match_entry_free(entry);
 
     entry = match_entry_create("/bar");
     entry->host.base = ".bar.com";
     entry->host.len = strlen(".bar.com");
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
+    match_entry_free(entry);
 
     entry = match_entry_create("/bar");
     entry->host.base = "a.bar.com";
@@ -64,6 +65,7 @@ START_TEST (test_hosts)
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri1);
+    match_entry_free(entry);
 
     r3_tree_free(n);
 }
@@ -88,4 +90,3 @@ int main (int argc, char *argv[]) {
     srunner_free(runner);
     return number_failed;
 }
-

--- a/tests/check_http_scheme.c
+++ b/tests/check_http_scheme.c
@@ -34,43 +34,51 @@ START_TEST (test_http_scheme)
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri0);
+    match_entry_free(entry);
 
     entry = match_entry_create("/foo");
     entry->http_scheme = SCHEME_HTTP;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri0);
+    match_entry_free(entry);
 
     entry = match_entry_create("/bar");
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
+    match_entry_free(entry);
 
     entry = match_entry_create("/bar");
     entry->http_scheme = SCHEME_HTTP;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
+    match_entry_free(entry);
 
     entry = match_entry_create("/bar");
     entry->http_scheme = SCHEME_HTTPS;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri1);
+    match_entry_free(entry);
 
     entry = match_entry_create("/boo");
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
+    match_entry_free(entry);
 
     entry = match_entry_create("/boo");
     entry->http_scheme = SCHEME_HTTP;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri2);
+    match_entry_free(entry);
 
     entry = match_entry_create("/boo");
     entry->http_scheme = SCHEME_HTTPS;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri2);
+    match_entry_free(entry);
 
     r3_tree_free(n);
 }

--- a/tests/check_remote_addr.c
+++ b/tests/check_remote_addr.c
@@ -42,6 +42,7 @@ START_TEST (test_remote_addrs)
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri0);
+    match_entry_free(entry);
 
     entry = match_entry_create("/bar");
     entry->remote_addr.base = "127.0.0.1";
@@ -49,13 +50,14 @@ START_TEST (test_remote_addrs)
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri1);
+    match_entry_free(entry);
 
     entry = match_entry_create("/bar");
     entry->remote_addr.base = "127.0.0.2";
     entry->remote_addr.len = sizeof("127.0.0.2") - 1;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
-
+    match_entry_free(entry);
 
     entry = match_entry_create("/boo");
     entry->remote_addr.base = "127.0.0.1";
@@ -63,6 +65,7 @@ START_TEST (test_remote_addrs)
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri2);
+    match_entry_free(entry);
 
     entry = match_entry_create("/boo");
     entry->remote_addr.base = "127.0.0.2";
@@ -70,18 +73,21 @@ START_TEST (test_remote_addrs)
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri2);
+    match_entry_free(entry);
 
     entry = match_entry_create("/boo");
     entry->remote_addr.base = "127.0.1.2";
     entry->remote_addr.len = sizeof("127.0.1.2") - 1;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
+    match_entry_free(entry);
 
     entry = match_entry_create("/boo");
     entry->remote_addr.base = "127.0.1.333";   // invalid ip address
     entry->remote_addr.len = sizeof("127.0.1.333") - 1;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
+    match_entry_free(entry);
 
     r3_tree_free(n);
 }
@@ -139,18 +145,21 @@ START_TEST (test_remote_addrs_ipv6)
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri0);
+    match_entry_free(entry);
 
     entry = match_entry_create("/foo");
     entry->remote_addr.base = "fe80:fe80::2";
     entry->remote_addr.len = sizeof("fe80:fe80::2") - 1;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
+    match_entry_free(entry);
 
     entry = match_entry_create("/foo");
     entry->remote_addr.base = "fe88:fe80::1";
     entry->remote_addr.len = sizeof("fe88:fe80::1") - 1;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
+    match_entry_free(entry);
 
     entry = match_entry_create("/bar");
     entry->remote_addr.base = "fe80:fe80::1";
@@ -158,12 +167,14 @@ START_TEST (test_remote_addrs_ipv6)
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri1);
+    match_entry_free(entry);
 
     entry = match_entry_create("/bar");
     entry->remote_addr.base = "fe88:fe80::1";
     entry->remote_addr.len = sizeof("fe88:fe80::1") - 1;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
+    match_entry_free(entry);
 
     entry = match_entry_create("/goo");
     entry->remote_addr.base = "::1";
@@ -171,12 +182,14 @@ START_TEST (test_remote_addrs_ipv6)
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route != NULL);
     ck_assert(matched_route->data == &uri2);
+    match_entry_free(entry);
 
     entry = match_entry_create("/goo");
     entry->remote_addr.base = "::2";
     entry->remote_addr.len = sizeof("::2") - 1;
     matched_route = r3_tree_match_route(n, entry);
     ck_assert(matched_route == NULL);
+    match_entry_free(entry);
 
     r3_tree_free(n);
 }


### PR DESCRIPTION
A couple of testcases did not free its `match_entry` allocations, which triggers leak indications.

Visible when building and running tests using the leak sanitizer, i.e
```
CFLAGS="-fno-omit-frame-pointer -fsanitize=leak" cmake ..
make all test
```