### PR TITLE
Corrections in `str_array`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,10 @@ find_package(Check)
 find_package(PCRE REQUIRED)
 
 include(CheckSymbolExists)
+include(CheckIncludeFile)
 check_symbol_exists(strdup string.h HAVE_STRDUP)
 check_symbol_exists(strndup string.h HAVE_STRNDUP)
+check_include_file(stdbool.h HAVE_STDBOOL_H)
 configure_file(config.h.cmake config.h)
 
 add_subdirectory(src)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -1,2 +1,3 @@
 #cmakedefine HAVE_STRDUP @HAVE_STRDUP@
 #cmakedefine HAVE_STRNDUP @HAVE_STRNDUP@
+#cmakedefine HAVE_STDBOOL_H @HAVE_STDBOOL_H@

--- a/include/r3.h
+++ b/include/r3.h
@@ -13,21 +13,12 @@
 #include <pcre.h>
 
 #ifdef HAVE_STDBOOL_H
-
-#include <stdbool.h>
-
-#else
-
-#if !defined(bool) && !defined(__cplusplus)
+#  include <stdbool.h>
+#elif !defined(bool) && !defined(__cplusplus)
 typedef unsigned char bool;
-#endif
-#ifndef false
-#    define false 0
-#endif
-#ifndef true
-#    define true 1
-#endif
-
+#  define bool bool /* For redefinition guards */
+#  define false 0
+#  define true 1
 #endif
 
 #include "str_array.h"

--- a/include/str_array.h
+++ b/include/str_array.h
@@ -8,8 +8,16 @@
 #ifndef STR_ARRAY_H
 #define STR_ARRAY_H
 
-#include "r3.h"
 #include "memory.h"
+
+#ifdef HAVE_STDBOOL_H
+#  include <stdbool.h>
+#elif !defined(bool) && !defined(__cplusplus)
+typedef unsigned char bool;
+#  define bool bool /* For redefinition guards */
+#  define false 0
+#  define true 1
+#endif
 
 typedef struct _str_array {
   R3_VECTOR(r3_iovec_t) slugs;

--- a/include/str_array.h
+++ b/include/str_array.h
@@ -32,8 +32,8 @@ void str_array_dump_slugs(const str_array *l);
 
 void str_array_dump(const str_array *l);
 
-#define str_array_fetch(t,i)  t->tokens[i]
-#define str_array_len(t)  t->len
-#define str_array_cap(t)  t->cap
+#define str_array_fetch(t,i)  t->tokens.entries[i]
+#define str_array_len(t)  t->tokens.size
+#define str_array_cap(t)  t->tokens.capacity
 
 #endif /* !STR_ARRAY_H */

--- a/include/str_array.h
+++ b/include/str_array.h
@@ -24,16 +24,6 @@ typedef struct _str_array {
   R3_VECTOR(r3_iovec_t) tokens;
 } str_array;
 
-// str_array * str_array_create(int cap);
-
-bool str_array_slugs_full(const str_array * l);
-
-// bool str_array_tokens_full(const str_array * l);
-
-// bool str_array_resize(str_array *l, int new_cap);
-
-// bool str_array_append_slug(str_array * l, char * slug);
-
 bool str_array_append(str_array * l, const char * token, unsigned int len);
 
 void str_array_free(str_array *l);
@@ -41,8 +31,6 @@ void str_array_free(str_array *l);
 void str_array_dump_slugs(const str_array *l);
 
 void str_array_dump(const str_array *l);
-
-str_array * split_route_pattern(char *pattern, int pattern_len);
 
 #define str_array_fetch(t,i)  t->tokens[i]
 #define str_array_len(t)  t->len

--- a/tests/check_str_array.c
+++ b/tests/check_str_array.c
@@ -8,31 +8,59 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <check.h>
-#include "r3.h"
-#include "r3_slug.h"
+#include "str_array.h"
 
 START_TEST (test_str_array)
 {
-    match_entry * entry = match_entry_create("/foo");
-    ck_assert(entry);
+    str_array *vars = r3_mem_alloc(sizeof(str_array));
+    memset(vars, 0, sizeof(*vars));
 
     char *test_str = "abc";
-    ck_assert( str_array_append(&entry->vars, test_str, strlen(test_str)));
-    ck_assert( entry->vars.tokens.size == 1 );
+    ck_assert( str_array_append(vars, test_str, strlen(test_str)));
+    ck_assert( vars->tokens.size == 1 );
 
     char *test_str1 = "foo";
-    ck_assert( str_array_append(&entry->vars, test_str1, strlen(test_str)));
-    ck_assert( entry->vars.tokens.size == 2 );
+    ck_assert( str_array_append(vars, test_str1, strlen(test_str1)));
+    ck_assert( vars->tokens.size == 2 );
 
     char *test_str2 = "bar";
-    ck_assert( str_array_append(&entry->vars, test_str2, strlen(test_str)));
-    ck_assert( entry->vars.tokens.size == 3 );
+    ck_assert( str_array_append(vars, test_str2, strlen(test_str2)));
+    ck_assert( vars->tokens.size == 3 );
 
     char *test_str3 = "zoo";
-    ck_assert( str_array_append(&entry->vars, test_str3, strlen(test_str)));
-    ck_assert( entry->vars.tokens.size == 4 );
+    ck_assert( str_array_append(vars, test_str3, strlen(test_str3)));
+    ck_assert( vars->tokens.size == 4 );
 
-    match_entry_free(entry);
+    str_array_free(vars);
+    free(vars);
+}
+END_TEST
+
+START_TEST (test_access_macros)
+{
+    str_array *vars = r3_mem_alloc(sizeof(str_array));
+    memset(vars, 0, sizeof(*vars));
+    ck_assert( str_array_len(vars) == 0);
+    ck_assert( str_array_cap(vars) == 0);
+
+    r3_vector_reserve(NULL, &vars->tokens, 4);
+    ck_assert( str_array_len(vars) == 0);
+    ck_assert( str_array_cap(vars) == 4);
+
+    char *token1 = "first";
+    char *token2 = "second";
+    ck_assert( str_array_append(vars, token1, strlen(token1)));
+    ck_assert( str_array_append(vars, token2, strlen(token2)));
+    ck_assert( str_array_len(vars) == 2);
+    ck_assert( str_array_cap(vars) == 4);
+
+    ck_assert( strncmp(str_array_fetch(vars,0).base, "first", 5) == 0);
+    ck_assert( str_array_fetch(vars,0).len == 5);
+    ck_assert( strncmp(str_array_fetch(vars,1).base, "second", 6) == 0);
+    ck_assert( str_array_fetch(vars,1).len == 6);
+
+    str_array_free(vars);
+    free(vars);
 }
 END_TEST
 
@@ -40,6 +68,7 @@ Suite* r3_suite (void) {
     Suite *suite = suite_create("str_array test");
     TCase *tcase = tcase_create("testcase");
     tcase_add_test(tcase, test_str_array);
+    tcase_add_test(tcase, test_access_macros);
     suite_add_tcase(suite, tcase);
     return suite;
 }


### PR DESCRIPTION
This PR addresses a couple of issues found in `str_array`:

-  Update the faulty access macros for `str_array`.
  Adds a testcase for the usage of the access macros, and also updates the testsuite to only include what `str_array` requires.
  This shows that `str_array` can be used separately by users, which was possible in version 1.3.4 as well.
- Remove declarations for nonexisting functions in `str_array.h`
- Remove cyclic dependency between `str_array.h` and `r3.h`.
  This also makes sure we don't get warnings when building with clang.
- Check for existence of `stdbool.h` during CMake builds.
  The headerfile is searched for during autogen/autoconf builds to determine when to include `stdbool.h`.
  This let CMake builds have the same behavior.