### PR TITLE
Remove fixed alignment

### DIFF
--- a/include/r3.h
+++ b/include/r3.h
@@ -51,9 +51,7 @@ struct _node  {
 
     // the pointer of R3Route data
     void * data;
-
-    // almost less than 255
-} __attribute__((aligned(64)));
+};
 
 #define r3_node_edge_pattern(node,i) node->edges.entries[i].pattern.base
 #define r3_node_edge_pattern_len(node,i) node->edges.entries[i].pattern.len
@@ -61,10 +59,9 @@ struct _node  {
 struct _edge {
     r3_iovec_t pattern; // 8 bytes
     R3Node * child; // 8 bytes
-    // unsigned int pattern_len; // 4byte
     unsigned int opcode; // 4byte
     unsigned int has_slug; // 4byte
-} __attribute__((aligned(64)));
+};
 
 struct _R3Route {
     r3_iovec_t path;
@@ -84,7 +81,7 @@ struct _R3Route {
 
     int          http_scheme;   // can be (SCHEME_HTTP or SCHEME_HTTPS)
 
-} __attribute__((aligned(64)));
+};
 
 typedef struct _R3Entry match_entry;
 struct _R3Entry {
@@ -98,7 +95,7 @@ struct _R3Entry {
     r3_iovec_t remote_addr;
 
     int          http_scheme;
-} __attribute__((aligned(64)));
+};
 
 
 R3Node * r3_tree_create(int cap);


### PR DESCRIPTION
When building and running tests using an [undefined behavior sanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) it complains about misaligned member access ([log](https://github.com/Nordix/r3/runs/3923478640?check_suite_focus=true)).
(The flag `-fno-sanitize-recover=all` is important here to make sure a testcase fails when found..)

Some structs are set to have 64 byte alignment, but when they are allocated this is disregarded and gives above errors.
This PR removed the fixed alignment and let the compiler handle it.

Using [`pahole`](https://developers.redhat.com/blog/2016/06/01/how-to-avoid-wasting-megabytes-of-memory-a-few-bytes-at-a-time#tools) the size of the structs changes:
| Struct | Old size | New size |
| -- | -- | -- |
| R3Node /_node | 128 | 80 |
| R3Edge /_edge | 64 | 32 |
| R3Route / _R3Route | 128 | 128 |
| match_entry / _R3Entry | 128 | 104 |


Running `./run-benchmark` gives equivalent results before and after this PR.