### PR TITLE
Use recommended Coveralls GitHub action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ jobs:
     - name: Prepare
       run: |
         sudo apt update -qq
-        sudo apt install -qq check
-        pip install cpp-coveralls
+        sudo apt install -qq check lcov
     - uses: actions/checkout@v2
     - name: Build
       run: |
@@ -20,9 +19,14 @@ jobs:
       run: sudo make install
     - name: Run tests
       run: make check
+    - name: Collect coverage
+      run: lcov --capture -d '.' --exclude '/usr*' -o coverage.info
     - name: Upload coverage
       if: github.repository == 'c9s/r3'
-      run: coveralls --exclude php
+      uses: coverallsapp/github-action@1.1.3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: coverage.info
 
   cmake:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Coverage reporting using `cpp-coveralls` seems not to work as expected in Github Actions.

In Travis there is built-in support for Coveralls and jobs are provided a needed Coveralls token.
In Github the token needs to be provided via an environment variable `COVERALLS_REPO_TOKEN`, and to avoid making the token public it can be provided via a secret. The drawback of using secrets is that jobs triggered by forks will not be given the secret for security reasons, i.e coverage will not be collected for PRs.

This PR uses an alternative way by collecting the coverage using lcov, and pushing the result to the Coveralls site using their supported [Github Action](https://github.com/coverallsapp/github-action).