### PR TITLE
Handle incomplete slug pattern when inserting a route

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -589,6 +589,9 @@ R3Route * r3_node_append_route(R3Node *tree, const char * path, int path_len, in
  */
 R3Route * r3_tree_insert_routel_ex(R3Node *tree, int method, const char *path, int path_len, void *data, char **errstr) {
     R3Node * ret = r3_tree_insert_pathl_ex(tree, path, path_len, method, 1, data, errstr);
+    if (ret == NULL) {
+        return NULL;
+    }
     R3Route *router = ret->routes.entries + (ret->routes.size - 1);
     get_slugs(router, path, path_len);
 

--- a/tests/check_routes2.c
+++ b/tests/check_routes2.c
@@ -80,11 +80,28 @@ START_TEST (common_pattern)
 }
 END_TEST
 
+START_TEST (incomplete_pattern)
+{
+    R3Node * n = r3_tree_create(10);
+    R3Route * r;
+
+    char * uri0 = "{slug";
+    r = r3_tree_insert_routel(n, 0, uri0, strlen(uri0), &uri0);
+    ck_assert(r == NULL);
+    char * uri1 = "/foo/{slug";
+    r = r3_tree_insert_routel(n, 0, uri1, strlen(uri1), &uri1);
+    ck_assert(r == NULL);
+
+    r3_tree_free(n);
+}
+END_TEST
+
 Suite* r3_suite (void) {
     Suite *suite = suite_create("r3 routes2 tests");
     TCase *tcase = tcase_create("testcase");
     tcase_add_test(tcase, greedy_pattern);
     tcase_add_test(tcase, common_pattern);
+    tcase_add_test(tcase, incomplete_pattern);
     suite_add_tcase(suite, tcase);
     return suite;
 }


### PR DESCRIPTION
This avoids a seg. fault when inserting an incomplete pattern.
Includes a test that triggers the fault.