### PR TITLE
Add Coverity Scan to CI

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,37 @@
+name: coverity
+on: [push, pull_request]
+
+jobs:
+  analyze:
+    if: github.repository == 'c9s/r3'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download Coverity
+      run: |
+        cd ..
+        wget -q https://scan.coverity.com/download/linux64 --post-data "token=${COVERITY_TOKEN}&project=r3" -O coverity-linux64.tgz
+        mkdir coverity
+        tar xzf coverity-linux64.tgz --strip 1 -C coverity
+        echo "$(pwd)/coverity/bin" >> $GITHUB_PATH
+      env:
+        COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}
+
+    - name: Build with Coverity
+      run: |
+        ./autogen.sh
+        ./configure --enable-check --enable-debug
+        cov-build --dir cov-int make V=1
+
+    - name: Submit the result to Coverity
+      run: |
+        tar czvf r3.tgz cov-int
+        curl \
+          --form token=${COVERITY_TOKEN} \
+          --form email=yoanlin93+github@gmail.com \
+          --form file=@r3.tgz \
+          --form version=${GITHUB_SHA} \
+          https://scan.coverity.com/builds?project=r3
+      env:
+        COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}

--- a/src/node.c
+++ b/src/node.c
@@ -720,18 +720,11 @@ R3Node * r3_tree_insert_pathl_ex(R3Node *tree, const char *path, unsigned int pa
         if ( slug_cnt > 1 ) {
             unsigned int   slug_len;
             const char *p = r3_slug_find_placeholder(path, path_len, &slug_len);
-
-#ifdef DEBUG
             assert(p);
-#endif
 
             // find the next one '{', then break there
-            if(p) {
-                p = r3_slug_find_placeholder(p + slug_len + 1, path_len - slug_len - 1, NULL);
-            }
-#ifdef DEBUG
+            p = r3_slug_find_placeholder(p + slug_len + 1, path_len - slug_len - 1, NULL);
             assert(p);
-#endif
 
             // insert the first one edge, and break at "p"
             R3Node * child = r3_tree_create(3);
@@ -745,6 +738,7 @@ R3Node * r3_tree_insert_pathl_ex(R3Node *tree, const char *path, unsigned int pa
                 // there is one slug, let's see if it's optimiz-able by opcode
                 unsigned int   slug_len = 0;
                 const char *slug_p = r3_slug_find_placeholder(path, path_len, &slug_len);
+                assert(slug_p);
                 unsigned int   slug_pattern_len = 0;
                 const char *slug_pattern = r3_slug_find_pattern(slug_p, slug_len, &slug_pattern_len);
 


### PR DESCRIPTION
Coverity is a static code analysis tool which can find and warn about many hard-to-find faults.
This PR adds a CI job that triggers a scan, and a correction of the last existing issue.

Results will be available at:
https://scan.coverity.com/projects/r3

Fixes #110