### PR TITLE
Fix leak in r3_tree_insert_pathl_ex()

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -701,8 +701,12 @@ R3Node * r3_tree_insert_pathl_ex(R3Node *tree, const char *path, unsigned int pa
     char *err = NULL;
     e = r3_node_find_common_prefix(tree, path, path_len, &prefix_len, &err);
     if (err) {
-        // copy the error message pointer
-        if (errstr) *errstr = err;
+        if (errstr) {
+            // copy the error message pointer
+            *errstr = err;
+        } else {
+            free(err);
+        }
         return NULL;
     }
 

--- a/tests/check_tree.c
+++ b/tests/check_tree.c
@@ -595,8 +595,25 @@ START_TEST (test_insert_pathl_fail)
 }
 END_TEST
 
+START_TEST (test_insert_pathl_fail2)
+{
+    R3Node * n = r3_tree_create(10);
+    char *errstr = NULL;
+    R3Node * ret;
 
+    ret = r3_tree_insert_pathl_ex(n, "/foo", strlen("/foo"),  0, 0, 0, NULL);
+    ck_assert(ret);
 
+    /* Insert an incomplete pattern without requesting an error string */
+    ret = r3_tree_insert_pathl_ex(n, "/foo/{name:\\d{5}", strlen("/foo/{name:\\d{5}"),  0, 0, 0, NULL);
+    ck_assert(ret == NULL);
+
+    r3_tree_compile(n, &errstr);
+    ck_assert(errstr == NULL);
+
+    r3_tree_free(n);
+}
+END_TEST
 
 START_TEST (test_insert_pathl)
 {
@@ -862,6 +879,7 @@ Suite* r3_suite (void) {
         tcase = tcase_create("insert_testcase");
         tcase_add_test(tcase, test_insert_pathl);
         tcase_add_test(tcase, test_insert_pathl_fail);
+        tcase_add_test(tcase, test_insert_pathl_fail2);
         tcase_add_test(tcase, test_node_construct_and_free);
         suite_add_tcase(suite, tcase);
 


### PR DESCRIPTION
Includes a testcase triggering the issue when building with the leak sanitizer.

Fixes Resource leak (CID 355063) found by Coverity.