### PR TITLE
Use coverity-scan-action in CI

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,5 +1,7 @@
 name: coverity
-on: [push, pull_request]
+on:
+  push:
+    branches: [2.0]
 
 jobs:
   analyze:
@@ -7,27 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Download Coverity
-      run: |
-        cd ..
-        wget -q https://scan.coverity.com/download/linux64 --post-data "token=${{secrets.COVERITY_TOKEN}}&project=r3" -O coverity-linux64.tgz
-        mkdir coverity
-        tar xzf coverity-linux64.tgz --strip 1 -C coverity
-        echo "$(pwd)/coverity/bin" >> $GITHUB_PATH
-
-    - name: Build with Coverity
+    - uses: actions/checkout@v3
+    - name: Prepare
       run: |
         ./autogen.sh
-        ./configure --enable-check --enable-debug
-        cov-build --dir cov-int make V=1
-
-    - name: Submit the result to Coverity
-      run: |
-        tar czvf r3.tgz cov-int
-        curl \
-          --form token=${{secrets.COVERITY_TOKEN}} \
-          --form email=yoanlin93+github@gmail.com \
-          --form file=@r3.tgz \
-          --form version=${GITHUB_SHA} \
-          https://scan.coverity.com/builds?project=r3
+        ./configure --enable-check
+    - uses: vapier/coverity-scan-action@v1
+      with:
+        project: r3
+        email: yoanlin93+github@gmail.com
+        token: ${{ secrets.COVERITY_TOKEN }}


### PR DESCRIPTION
By using a maintained GitHub action to run Coverity jobs we hopefully don't have to do modifications when procedures change. This seems to fix the current token issue and also simplifies the CI job.

Additionally [coverity-scan-action](https://github.com/vapier/coverity-scan-action) adds a cache to avoid downloading the 1GB+ tool archive on every run.

[Here](https://github.com/bjosv/r3/actions/runs/6093667578/job/16533718984) are logs from a test run.