### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/slug.c
+++ b/src/slug.c
@@ -90,7 +90,6 @@ int r3_slug_parse(r3_slug_t *s, const char *needle, int needle_len, const char *
         return 0;
     }
 
-    int cnt = 0;
     int state = 0;
     const char * p = offset;
 
@@ -122,7 +121,6 @@ int r3_slug_parse(r3_slug_t *s, const char *needle, int needle_len, const char *
             if (s->pattern) {
                 s->pattern_len = p - s->pattern;
             }
-            cnt++;
             state--;
             p++;
             break;

--- a/tests/bench.c
+++ b/tests/bench.c
@@ -17,7 +17,7 @@
 
 
 
-unsigned long unixtime() {
+unsigned long unixtime(void) {
     struct timeval tp;
     if (gettimeofday((struct timeval *) &tp, (NULL)) == 0) {
         return tp.tv_sec;
@@ -25,7 +25,7 @@ unsigned long unixtime() {
     return 0;
 }
 
-double microtime() {
+double microtime(void) {
     struct timeval tp;
     long sec = 0L;
     double msec = 0.0;
@@ -93,7 +93,7 @@ void bench_append_csv(char *filename, int countOfB, ...) {
 
 
 
-int main()
+int main(void)
 {
     R3Node * n = r3_tree_create(1);
 

--- a/tests/bench.h
+++ b/tests/bench.h
@@ -22,9 +22,9 @@ typedef struct {
     double end;
 } bench;
 
-unsigned long unixtime();
+unsigned long unixtime(void);
 
-double microtime();
+double microtime(void);
 
 void bench_start(bench *b);
 

--- a/tests/check_tree.c
+++ b/tests/check_tree.c
@@ -304,7 +304,7 @@ START_TEST (test_node_construct_and_free)
 }
 END_TEST
 
-static R3Node * create_simple_str_tree() {
+static R3Node * create_simple_str_tree(void) {
     R3Node * n;
     n = r3_tree_create(10);
     r3_tree_insert_path(n, "/zoo", NULL);

--- a/tests/check_tree.c
+++ b/tests/check_tree.c
@@ -714,19 +714,19 @@ START_TEST(test_route_cmp)
     R3Route *r1 = r3_node_append_route(n,test_str, strlen(test_str),0,0);
     match_entry * m = match_entry_create("/blog/post");
 
-    fail_if( r3_route_cmp(r1, m) == -1, "should match");
+    ck_assert_msg(r3_route_cmp(r1, m) == 0, "should match");
 
     r1->request_method = METHOD_GET;
     m->request_method = METHOD_GET;
-    fail_if( r3_route_cmp(r1, m) == -1, "should match");
+    ck_assert_msg(r3_route_cmp(r1, m) == 0, "should match");
 
     r1->request_method = METHOD_GET;
     m->request_method = METHOD_POST;
-    fail_if( r3_route_cmp(r1, m) == 0, "should be different");
+    ck_assert_msg(r3_route_cmp(r1, m) == -1, "should be different");
 
     r1->request_method = METHOD_GET;
     m->request_method = METHOD_POST | METHOD_GET;
-    fail_if( r3_route_cmp(r1, m) == -1, "should match");
+    ck_assert_msg(r3_route_cmp(r1, m) == 0, "should match");
 
     match_entry_free(m);
     r3_tree_free(n);


### PR DESCRIPTION
**Clang warnings:**
When building using a newer Clang with additional diagnostics the following warnings are indicated:
- unused-but-set-variable
- strict-prototypes

This is corrected by removing the unused variable and adding `void` to function definitions/declarations.
Reproducible using `CC="clang-13" CFLAGS="-Wall -pedantic" cmake ..`   


**GCC warnings:**
When building with gcc >= 11 the following warning is indicated:
- format-extra-args

This is corrected by replacing the use of the deprecated libcheck API `fail_if()` with `ck_assert_msg` according to [recommendation](https://github.com/libcheck/check/pull/298).

This warning can be seen in a [CI run](https://github.com/c9s/r3/actions/runs/6612099824/job/17957247226#step:6:25). 
 