### PR TITLE
Support C23 projects

### DIFF
--- a/include/r3.h
+++ b/include/r3.h
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <pcre.h>
 
+#if __STDC_VERSION__ <= 201710L
 #ifdef HAVE_STDBOOL_H
 #  include <stdbool.h>
 #elif !defined(bool) && !defined(__cplusplus)
@@ -19,6 +20,7 @@ typedef unsigned char bool;
 #  define bool bool /* For redefinition guards */
 #  define false 0
 #  define true 1
+#endif
 #endif
 
 #include "str_array.h"

--- a/include/str_array.h
+++ b/include/str_array.h
@@ -10,6 +10,7 @@
 
 #include "memory.h"
 
+#if __STDC_VERSION__ <= 201710L
 #ifdef HAVE_STDBOOL_H
 #  include <stdbool.h>
 #elif !defined(bool) && !defined(__cplusplus)
@@ -17,6 +18,7 @@ typedef unsigned char bool;
 #  define bool bool /* For redefinition guards */
 #  define false 0
 #  define true 1
+#endif
 #endif
 
 typedef struct _str_array {

--- a/src/match_entry.c
+++ b/src/match_entry.c
@@ -10,7 +10,6 @@
 #include <string.h>
 #include <pcre.h>
 #include <assert.h>
-#include <stdbool.h>
 
 #include "r3.h"
 


### PR DESCRIPTION
Don't define `true`/`false`/`bool` when r3 is used by C23 projects since
C23 already has a bool type and predefined constants.