### PR TITLE
Install headers in correct path when using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ install(
     include/r3_json.h
     include/str_array.h
     include/r3.hpp
-  DESTINATION include)
+  DESTINATION include/r3)
 
 # Configure substitutions for r3.pc. The variables set here must match the
 # @<values>@ in r3.pc.in.


### PR DESCRIPTION
pkg-config provides users with the include path `../include/r3`
while CMake installs the headers directly under `../include/`.

This PR corrects the installation path to match the generated `r3.pc` file
and to get the same result as when using autoconf.

The [example in the README](https://github.com/c9s/r3/blob/2.0/README.md#api) also shows that the `<r3/r3.h>` path is expected.
