### PR TITLE
Improve CI security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Automated dependency updates.
+#
+# For configuration options see:
+# https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
       uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 # v2.2.3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: coverage.info
+        file: coverage.info
+        format: lcov
 
   cmake:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   autotools:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       run: |
         sudo apt update -qq
         sudo apt install -qq check lcov
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Build
       run: |
         ./autogen.sh
@@ -23,7 +23,7 @@ jobs:
       run: lcov --capture -d '.' --exclude '/usr*' -o coverage.info
     - name: Upload coverage
       if: github.repository == 'c9s/r3'
-      uses: coverallsapp/github-action@1.1.3
+      uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 # v2.2.3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: coverage.info
@@ -35,7 +35,7 @@ jobs:
       run: |
         sudo apt update -qq
         sudo apt install -qq check ninja-build
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Build and test
       run: |
         mkdir build && cd build
@@ -56,7 +56,7 @@ jobs:
       run: |
         sudo apt update -qq
         sudo apt install -qq check
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Build
       env:
         CC: ${{ matrix.compiler }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Prepare
       run: |
         ./autogen.sh
         ./configure --enable-check
-    - uses: vapier/coverity-scan-action@v1
+    - uses: vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85 # v1.8.0
       with:
         project: r3
         email: yoanlin93+github@gmail.com

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [2.0]
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     if: github.repository == 'c9s/r3'


### PR DESCRIPTION
Improve security for CI runs according to OpenSSF recommendations:
- Add dependabot for automated dependency updates
 https://github.com/ossf/scorecard/blob/main/docs/checks.md#dependency-update-tool
- Pin versions of Github actions in CI
  https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

- Set read-only permission for Github Actions in CI
 https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions






