### PR TITLE
Fix buffer overflow in `r3_tree_compile_patterns`

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -164,30 +164,60 @@ int r3_tree_compile(R3Node *n, char **errstr)
  * Return 0 if success
  */
 int r3_tree_compile_patterns(R3Node * n, char **errstr) {
-    R3Edge *e;
-    char * p;
-    char * cpat = calloc(1, sizeof(char) * 64 * 3); // XXX
-    if (!cpat) {
+    R3Edge *e = NULL;
+    char *p = NULL;
+
+    char **slug_pats = calloc(n->edges.size, sizeof(char *));
+    if (!slug_pats) {
         int r = asprintf(errstr, "Can not allocate memory");
         if (r) {};
         return -1;
     }
 
+    // Compile and cache all slugs to get the required size of cpat.
+    size_t cpat_len = 1; // null terminator
+    unsigned int i = 0;
+    for (i = 0; i < n->edges.size; i++) {
+        e = n->edges.entries + i;
+        if (e->has_slug) {
+            // compile "foo/{slug}" to "foo/[^/]+"
+            slug_pats[i] = r3_slug_compile(e->pattern.base, e->pattern.len);
+            if (!slug_pats[i]) {
+                int r = asprintf(errstr, "Can not allocate memory");
+                if (r) {};
+                for (unsigned int k = 0; k < i; k++) free(slug_pats[k]);
+                free(slug_pats);
+                return -1;
+            }
+            cpat_len += strlen(slug_pats[i]);
+        } else {
+            cpat_len += e->pattern.len + 3; // "^(" + pattern + ")"
+        }
+        if ( i + 1 < n->edges.size ) {
+            cpat_len += 1; // "|" separator
+        }
+    }
+
+    char *cpat = calloc(1, cpat_len);
+    if (!cpat) {
+        int r = asprintf(errstr, "Can not allocate memory");
+        if (r) {};
+        for (i = 0; i < n->edges.size; i++) free(slug_pats[i]);
+        free(slug_pats);
+        return -1;
+    }
+
     p = cpat;
     int opcode_cnt = 0;
-    unsigned int i = 0;
-    for (; i < n->edges.size ; i++) {
+    for (i = 0; i < n->edges.size ; i++) {
         e = n->edges.entries + i;
         if (e->opcode) {
             opcode_cnt++;
         }
 
         if (e->has_slug) {
-            // compile "foo/{slug}" to "foo/[^/]+"
-            char * slug_pat = r3_slug_compile(e->pattern.base, e->pattern.len);
-            info("slug_pat for pattern: %s\n",slug_pat);
-            strcat(p, slug_pat);
-            free(slug_pat);
+            info("slug_pat for pattern: %s\n",slug_pats[i]);
+            strcat(p, slug_pats[i]);
             info("temp pattern: %s\n",cpat);
         } else {
             strncat(p,"^(", 2);
@@ -199,16 +229,17 @@ int r3_tree_compile_patterns(R3Node * n, char **errstr) {
             strncat(p++,")", 1);
         }
 
-        if ( i + 1 < n->edges.size && n->edges.size > 1 ) {
+        if ( i + 1 < n->edges.size ) {
             strncat(p++,"|",1);
         }
     }
+    for (i = 0; i < n->edges.size; i++) free(slug_pats[i]);
+    free(slug_pats);
 
     info("pattern: %s\n",cpat);
 
     // if all edges use opcode, we should skip the combined_pattern.
     if ( opcode_cnt == n->edges.size ) {
-        // free(cpat);
         n->compare_type = NODE_COMPARE_OPCODE;
     } else {
         n->compare_type = NODE_COMPARE_PCRE;

--- a/tests/check_tree.c
+++ b/tests/check_tree.c
@@ -864,6 +864,88 @@ START_TEST(test_insert_route)
 }
 END_TEST
 
+START_TEST (test_compile_patterns_many_edges)
+{
+    R3Node * n = r3_tree_create(10);
+    char path[64];
+    char *paths[24];
+    int data = 1;
+    char *errstr = NULL;
+    const int num_paths = sizeof(paths) / sizeof(*paths);
+
+    /* Insert a slug plus 24 literal siblings under a shared prefix "/post/".
+     * Each literal starts with a distinct character so they become separate
+     * sibling edges, i.e. 25 edges in total. The slug makes the node use
+     * NODE_COMPARE_PCRE, so the pattern (^(\d+)|^(a_route)|^(b_route)|...) is
+     * built and used for matching.
+     */
+    r3_tree_insert_path(n, "/post/{id:\\d+}", &data);
+    for (int i = 0; i < num_paths; i++) {
+        char c = 'a' + i;
+        snprintf(path, sizeof(path), "/post/%c_endpoint_route_%c", c, c);
+        paths[i] = strdup(path);
+        r3_tree_insert_pathl(n, paths[i], strlen(paths[i]), &data);
+    }
+
+    int err = r3_tree_compile(n, &errstr);
+    ck_assert(err == 0);
+
+    /* Verify literal siblings and the slug all match correctly. */
+    R3Node *matched = r3_tree_match(n, "/post/a_endpoint_route_a", NULL);
+    ck_assert(matched != NULL);
+
+    matched = r3_tree_match(n, "/post/x_endpoint_route_x", NULL);
+    ck_assert(matched != NULL);
+
+    matched = r3_tree_match(n, "/post/12345", NULL);
+    ck_assert(matched != NULL);
+
+    SAFE_FREE(errstr);
+    r3_tree_free(n);
+    for (int i = 0; i < num_paths; i++) free(paths[i]);
+}
+END_TEST
+
+START_TEST (test_compile_patterns_long_patterns)
+{
+    R3Node * n = r3_tree_create(10);
+    char path[128];
+    char *paths[5];
+    int data = 1;
+    char *errstr = NULL;
+    const int num_paths = sizeof(paths) / sizeof(*paths);
+
+    /* A slug sibling plus 5 literal siblings, each 60-char with a distinct
+     * leading char (aaa..., bbb..., ...), all under a shared prefix.
+     */
+    r3_tree_insert_path(n, "/post/{id:\\d+}", &data);
+    for (int i = 0; i < num_paths; i++) {
+        char c = 'a' + i;
+        int off = snprintf(path, sizeof(path), "/post/%c", c);
+        memset(path + off, c, 59); // leading char + 59 more
+        path[off + 59] = '\0';
+        paths[i] = strdup(path);
+        r3_tree_insert_pathl(n, paths[i], strlen(paths[i]), &data);
+    }
+
+    int err = r3_tree_compile(n, &errstr);
+    ck_assert(err == 0);
+
+    R3Node *matched = r3_tree_match(n, paths[0], NULL);
+    ck_assert(matched != NULL);
+
+    matched = r3_tree_match(n, paths[num_paths - 1], NULL);
+    ck_assert(matched != NULL);
+
+    matched = r3_tree_match(n, "/post/98765", NULL);
+    ck_assert(matched != NULL);
+
+    SAFE_FREE(errstr);
+    r3_tree_free(n);
+    for (int i = 0; i < num_paths; i++) free(paths[i]);
+}
+END_TEST
+
 Suite* r3_suite (void) {
         Suite *suite = suite_create("r3 core tests");
         TCase *tcase = tcase_create("common_prefix_testcase");
@@ -885,6 +967,8 @@ Suite* r3_suite (void) {
 
         tcase = tcase_create("compile_testcase");
         tcase_add_test(tcase, test_compile);
+        tcase_add_test(tcase, test_compile_patterns_many_edges);
+        tcase_add_test(tcase, test_compile_patterns_long_patterns);
         tcase_add_test(tcase, test_compile_fail);
         tcase_add_test(tcase, test_route_cmp);
         tcase_add_test(tcase, test_insert_route);


### PR DESCRIPTION
The combined regex pattern buffer was a hardcoded 192 bytes, which overflows when a node has many edges or long edge patterns. The buffer is now sized dynamically: slugs are compiled once into a cache, and the exact length of the combined pattern is computed before allocation.

- Also drop a redundant condition in the edge separator check. In `i + 1 < n->edges.size && n->edges.size > 1`, the second clause is always true whenever the first holds (i is unsigned, so i + 1 < size implies size >= 2), so it is removed.

- Add regression tests exercising two overflow paths: many sibling edges and a few long-named edges, both producing a combined pattern well beyond the old 192-byte limit.

Kept the error string, but optionally we could change it to `Cannot allocate memory` as from `strerror(ENOMEM)`.
