### PR TITLE
Fix out-of-bounds read in `r3_node_find_common_prefix`

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -28,7 +28,7 @@
 
 static int strndiff(const char * d1, const char * d2, unsigned int n) {
     const char * o = d1;
-    while ( *d1 == *d2 && n-- > 0 ) {
+    while ( n-- > 0 && *d1 == *d2 ) {
         d1++;
         d2++;
     }
@@ -609,10 +609,19 @@ R3Edge * r3_node_find_common_prefix(R3Node *n, const char *path, int path_len, i
     int edge_prefix, prefix = 0;
     *prefix_len = 0;
     R3Edge *e = NULL;
+
+    if (path_len < 0) {
+        return NULL;
+    }
+
     // Check all edges to find the most common prefix
     for(i = 0; i < n->edges.size; i++) {
-        // ignore all edges with slug
-        edge_prefix = strndiff( (char*) path, n->edges.entries[i].pattern.base, n->edges.entries[i].pattern.len);
+        // Cap the compare length at the path length so strndiff never over-reads.
+        unsigned int max_len = n->edges.entries[i].pattern.len;
+        if ((unsigned int)path_len < max_len) {
+            max_len = path_len;
+        }
+        edge_prefix = strndiff( (char*) path, n->edges.entries[i].pattern.base, max_len);
 
         // no common, consider insert a new edge
         if (edge_prefix > prefix) {

--- a/tests/check_tree.c
+++ b/tests/check_tree.c
@@ -227,6 +227,34 @@ START_TEST (test_find_common_prefix_same_pattern2)
 }
 END_TEST
 
+START_TEST (test_find_common_prefix_short_path)
+{
+    /* Regression test for an over-read in r3_node_find_common_prefix: when the
+     * query path is a short prefix of a longer edge pattern, the comparison
+     * must not read past the end of the path.
+     */
+    R3Node * n = r3_tree_create(10);
+    char *edge_pattern = "/foobar/baz";
+    R3Edge * e = r3_node_append_edge(n);
+    r3_edge_initl(e, edge_pattern, strlen(edge_pattern), NULL);
+
+    /* Query "/foo" is a 4-char prefix of the edge pattern, copied into a
+     * buffer of exactly its length so an over-read lands out of bounds. */
+    const char *query = "/foo";
+    size_t query_len = strlen(query);
+    char *path = malloc(query_len);
+    memcpy(path, query, query_len);
+
+    int prefix_len = 0;
+    R3Edge *ret_edge = r3_node_find_common_prefix(n, path, query_len, &prefix_len, NULL);
+    ck_assert(ret_edge != NULL);
+    ck_assert_int_eq(prefix_len, 4);
+
+    free(path);
+    r3_tree_free(n);
+}
+END_TEST
+
 START_TEST (test_find_common_prefix_multi_edge)
 {
     R3Node * n = r3_tree_create(10);
@@ -873,6 +901,7 @@ Suite* r3_suite (void) {
         tcase_add_test(tcase, test_find_common_prefix_middle);
         tcase_add_test(tcase, test_find_common_prefix_same_pattern);
         tcase_add_test(tcase, test_find_common_prefix_same_pattern2);
+        tcase_add_test(tcase, test_find_common_prefix_short_path);
         tcase_add_test(tcase, test_find_common_prefix_multi_edge);
         suite_add_tcase(suite, tcase);
 


### PR DESCRIPTION
strndiff compared the query path against each edge pattern using the edge pattern length as the loop bound, and evaluated *d1 == *d2 before checking the counter. When the query path is a short prefix of a longer edge pattern, this reads past the end of the path buffer.

Three changes:
- strndiff now checks the length bound before dereferencing, so it never reads at n == 0.
- r3_node_find_common_prefix caps the comparison at the path length, so a short path is never read past its end.
- Reject a negative path_len up front, making the unsigned comparison safe.

Add a regression test that copies the query path into a heap buffer sized exactly to its length (no null terminator), so the over-read is flagged by AddressSanitizer.